### PR TITLE
Register engine with app isntead of Sprockets

### DIFF
--- a/lib/emblem/rails/engine.rb
+++ b/lib/emblem/rails/engine.rb
@@ -4,12 +4,7 @@ module Emblem
   module Rails
     class Engine < ::Rails::Engine
       initializer "ember_rails.setup", :after => :append_assets_path, :group => :all do |app|
-        sprockets = if ::Rails::VERSION::MAJOR == 4
-          Sprockets.respond_to?('register_engine') ? Sprockets : app.assets
-        else
-          app.assets
-        end
-        sprockets.register_engine '.emblem', Emblem::Rails::Template
+        app.assets.register_engine '.emblem', Emblem::Rails::Template
       end
     end
   end


### PR DESCRIPTION
I'm running a Rails 4 app that doesn't work properly with emblem-rails, and I've identified the issue. With the original code, registering the engine with `Sprockets` directly doesn't pick up any `.emblem` files. By registering the engine with `app.assets`, it works properly.

Note that [ember-rails uses app.assets](https://github.com/emberjs/ember-rails/blob/master/lib/ember_rails.rb#L33-L41), so I figured this change should be safe.
