### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ gem 'emblem-rails'
 # emblem source, and a fork of barber-emblem:
 
 gem "emblem-source", github: "machty/emblem.js"
-gem "barber-emblem", github: "simcha/barber-emblem"
 ```
 And then execute:
 


### PR DESCRIPTION
Now barber-emblem 0.1.2 is released that supports Ember.js 1.9.
